### PR TITLE
The rollup plugin hook can be specified as an object instead of a function

### DIFF
--- a/src/rollup-timer.js
+++ b/src/rollup-timer.js
@@ -80,11 +80,20 @@ export default class RollupTimer {
       }
       return
     }
-    const original = plugin[func]
-    plugin[func] = function (...args) {
-      const end = that._startTimer(timings)
-      const res = original.apply(this, args)
-      return that._handleResult(res, end)
+    const original = plugin[func];
+    if (typeof original === "function") {
+      plugin[func] = function (...args) {
+        const end = that._startTimer(timings);
+        const res = original.apply(this, args);
+        return that._handleResult(res, end);
+      };
+    } else {
+      const hook = original.hook;
+      plugin[func].hook = function (...args) {
+        const end = that._startTimer(timings);
+        const res = hook.apply(this, args);
+        return that._handleResult(res, end);
+      };
     }
   }
 


### PR DESCRIPTION
## Background
Rollup plugin hook can be specified as an object instead of function. In that case `rollup-timer` plugin fail.

### Example

Usually, `resolveId` is defined as an function

```js
return {
  resolveId(){
  },
  ...
}
```

but in some cases it can be defined as an object

```js
return {
  resolveId: {
    hook(){
    }
  }
}
```

This PR fixes the problem
